### PR TITLE
Hex SSP Kernel Unit Test

### DIFF
--- a/sspspace/__init__.py
+++ b/sspspace/__init__.py
@@ -1,4 +1,4 @@
 from .ssp import SSP, sim, bind, invert
 from .encoders import SSPEncoder, RandomSSPSpace, CyclicSSPSpace, JointSSPSpace, HexagonalSSPSpace, DiscreteSPSpace
 from .decoders import SSPDecoder, SSPSimilarityDecoder, train_decoder_net_sk, train_decoder_net_tf
-from .util import vecs_from_phases
+from .util import vecs_from_phases, joint_kernel

--- a/sspspace/__init__.py
+++ b/sspspace/__init__.py
@@ -1,4 +1,4 @@
 from .ssp import SSP, sim, bind, invert
 from .encoders import SSPEncoder, RandomSSPSpace, CyclicSSPSpace, JointSSPSpace, HexagonalSSPSpace, DiscreteSPSpace
 from .decoders import SSPDecoder, SSPSimilarityDecoder, train_decoder_net_sk, train_decoder_net_tf
-from .util import vecs_from_phases, joint_kernel
+from .util import vecs_from_phases

--- a/sspspace/util.py
+++ b/sspspace/util.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from scipy.special import gamma, jv
 from scipy.stats import qmc
 
 def sample_domain(bounds, num_samples):
@@ -77,3 +78,35 @@ def similarity_plot(self,ssp,n_grid=100,plot_type='heatmap',ax=None,**kwargs):
     else:
         raise NotImplementedError()
     return im
+
+def joint_kernel(x, n, kernel="hypergeom", length_scale=1):
+    # --------------------------------------------------
+    # See "Neurally-plausible radial basis kernels 
+    #      using distributed Fourier embeddings" for
+    #      an explanation of kernel formations.
+    # --------------------------------------------------
+    # Available here: https://arxiv.org/abs/2605.08458
+    # --------------------------------------------------
+    # x: N x n -> N x 1
+    x = (np.linalg.norm(np.atleast_2d(x), axis=1) / length_scale)[:,np.newaxis]
+
+    # Gaussian is consistent for all dimensionalities
+    if kernel=="gaussian":
+        return np.exp(-(x**2)/2)
+
+    # The 1-D case is identical for hypergeom and jinc
+    if n == 1:
+        return np.sinc(x/np.pi)
+    else:
+        # Approximate the kernels using a trapezoidal
+        # integration of the generic formulation
+        R = np.linspace(0, 1, 100, endpoint=True)[:,np.newaxis]
+        if kernel=="jinc":
+            px = (n * (R ** (n - 1)))
+        else:
+            px = np.ones_like(R)
+        return np.trapezoid(y=gamma(n/2) * 
+                              ((2 / (x @ R.T + 1e-6)) ** ((n/2) - 1)) *
+                              jv((n/2) - 1, x @ R.T) *
+                              px.T,
+                              x=R[:,0], axis=1)[:,np.newaxis]

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('../')
 
-from sspspace import SSP, SSPEncoder, RandomSSPSpace, HexagonalSSPSpace 
+from sspspace import SSP, SSPEncoder, RandomSSPSpace, HexagonalSSPSpace, joint_kernel
 import numpy as np
 
 
@@ -23,18 +23,31 @@ def test_hexagonal_encoding():
     xs = np.linspace(-2,2,100).reshape((-1,1))
     ys = np.linspace(-2,2,100).reshape((-1,1))
 
-    X, Y = np.meshgrid(xs, ys)
-    xys = np.vstack((X.flatten(), Y.flatten())).T
-    hex_encoder = HexagonalSSPSpace(domain_dim=2, n_rotates=1, n_scales=1)
-    hex_encoder.update_lengthscale(0.01)
+    for n in [1, 2]:
+        for k, ls in zip(["hypergeom", "jinc", "gaussian"],
+                        [0.2, 0.2, 0.5]):
+            
+            hex_encoder = HexagonalSSPSpace(domain_dim=n, n_rotates=17, n_scales=17, kernel=k)
+            hex_encoder.update_lengthscale(ls)
 
-    query_xys_ssp = hex_encoder.encode(xys)
-    origin_ssp = hex_encoder.encode([[0,0]])
+            if n==1:
+                xys = xs
+            else:
+                X, Y = np.meshgrid(xs, ys)
+                xys = np.vstack((X.flatten(), Y.flatten())).T    
 
-    sims = query_xys_ssp | origin_ssp
-    square_sims = sims.reshape((ys.shape[0], xs.shape[0]))
+            query_xys_ssp = hex_encoder.encode(xys)
+            origin_ssp = hex_encoder.encode(np.zeros((1,n)))
 
-    # TODO: Figure out numerical comparison
+            sims = query_xys_ssp | origin_ssp
+            ker_sims = joint_kernel(x=xys, n=n, kernel=k, length_scale=ls)
+
+            try:
+                assert np.allclose(sims, ker_sims, atol=5e-2)
+            except AssertionError:
+                print(f"Hexagonal SSP Encoding Error: Absolute difference between ground truth and induced kernel too large\nKernel: {k}\nDiff: {np.abs(sims - ker_sims).max()}")
+                continue
+            # print(f"PASS: Kernel: {k}, Domain Dimensionality: {n}, Length-scale: {ls}")
 
 def test_rand_gradient():
 
@@ -95,6 +108,7 @@ def test_hex_gradient():
 if __name__=='__main__':
     test_rand_gradient()
     test_hex_gradient()
+    test_hexagonal_encoding()
 
 #     import matplotlib.pyplot as plt
 #     plt.imshow(square_sims)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,7 +1,8 @@
 import sys
 sys.path.append('../')
 
-from sspspace import SSP, SSPEncoder, RandomSSPSpace, HexagonalSSPSpace, joint_kernel
+from sspspace import SSP, SSPEncoder, RandomSSPSpace, HexagonalSSPSpace
+from sspspace.util import joint_kernel
 import numpy as np
 
 


### PR DESCRIPTION
Introduces:
- sspspace.utils.joint_kernel
- tests/test_hexagonal_encoding()
  - jinc, gaussian, hypergeom
  - n = 1, 2
  - Appropriate length_scales for a centered 4x4 window size

Validation: 
- Able to run the testing script with no reported failures